### PR TITLE
V0.3.3 Update

### DIFF
--- a/src/main/java/marshmalliow/core/builder/JSONFactory.java
+++ b/src/main/java/marshmalliow/core/builder/JSONFactory.java
@@ -578,7 +578,7 @@ public class JSONFactory {
 	public <E extends JSONFile> E createJSONFileFromBase(Class<E> baseClass, Directory directory,
 			String jsonName, @Nullable JSONContainer rootContainer) throws IllegalArgumentException, IOException {
 		if(this.directoryManager != null) this.directoryManager.registerNewDirectoryIfAbsent(directory);
-		if (baseClass == null || !(baseClass.isInstance(JSONFile.class))) {
+		if (baseClass == null || !(JSONFile.class.isAssignableFrom(baseClass))) {
 			throw new IllegalArgumentException("The base class is not a child of JSONFile.");
 		}
 		
@@ -672,7 +672,7 @@ public class JSONFactory {
 	public <E extends JSONFile> E createSecuredJSONFileFromBase(Class<E> baseClass, Directory directory,
 			String jsonName, @Nullable JSONContainer rootContainer, FileCredentials credentials) throws IllegalArgumentException, IOException {
 		if(this.directoryManager != null) this.directoryManager.registerNewDirectoryIfAbsent(directory);
-		if (baseClass == null || !(baseClass.isInstance(JSONFile.class))) {
+		if (baseClass == null || !(JSONFile.class.isAssignableFrom(baseClass))) {
 			throw new IllegalArgumentException("The base class is not a child of JSONFile.");
 		}
 		

--- a/src/main/java/marshmalliow/core/json/JSONFile.java
+++ b/src/main/java/marshmalliow/core/json/JSONFile.java
@@ -78,9 +78,9 @@ public class JSONFile extends IOClass {
 	@Override
 	public void readFile(boolean forceRead) throws IOException {
 		synchronized (mutex) {
-			if(Files.size(getFullPath()) <= 0) {
-				this.isOpen = true; //If the file content is empty but the user still wants to read it, then define the file as open
-				this.content = new JSONObject();
+			if(!Files.exists(getFullPath()) || Files.size(getFullPath()) <= 0) {
+				this.isOpen = true; //If the file content is empty or doesn't exist on the disk, define the file as open
+				this.content = new JSONObject(); //TODO This is a major flaw because we cannot read a JSONArray file as JSONArray if the file doesn't exist
 			}else if((forceRead || !this.isOpen)) {
 				InputStream stream = null;
 				BufferedReader reader = null;


### PR DESCRIPTION
# Bugfixes
- Could not create child JSON file because inheritance check was broken
- Could not open a JSON file if it did not exist on the disk

# Known issues
- If we want to open a JSON file that does not exist on the disk, the program will open it as a JSONObject by default, making it impossible to open JSONArray